### PR TITLE
Fix : Octal literal in strict mode

### DIFF
--- a/lib/skein.js
+++ b/lib/skein.js
@@ -21,7 +21,7 @@ module.exports = function(input, format, output) {
 			[(0x80 + 0x40 + 0x4) << 24, 0]
 		],
 		c = [];
-	var buff = h.string2bytes("SHA3\1\0\0\0\0\2");
+	var buff = h.string2bytes("SHA3\\1\\0\\0\\0\\0\\2");
 	block(c, tweak, buff, 0);
 	tweak = [
 		[0, 0],


### PR DESCRIPTION
Following this error : 

```
18:47:31 [exp] SyntaxError in package/node_modules/x11-hash-js/lib/skein.js: Octal literal in strict mode (24:33)
18:47:31 [exp]   22 |           ],
18:47:31 [exp]   23 |           c = [];
18:47:31 [exp] > 24 |   var buff = h.string2bytes("SHA3\1\0\0\0\0\2");
18:47:31 [exp]      |                                   ^
18:47:31 [exp]   25 |   block(c, tweak, buff, 0);
18:47:31 [exp]   26 |   tweak = [
18:47:31 [exp]   27 |           [0, 0],
```