### PR TITLE
Fix : Deprecated octal escape sequence

### DIFF
--- a/lib/skein.js
+++ b/lib/skein.js
@@ -21,7 +21,7 @@ module.exports = function(input, format, output) {
             [(0x80 + 0x40 + 0x4) << 24, 0]
         ],
         c = [];
-    var buff = h.string2bytes('SHA3\1\0\0\0\0\2');
+    var buff = [83, 72, 65, 51, 1, 0, 0, 0, 0, 2];
     block(c, tweak, buff, 0);
     tweak = [
         [0, 0],


### PR DESCRIPTION
As of the ECMAScript 5 specification, octal escape sequences in string literals are deprecated and should not be used. Unicode escape sequences should be used instead.

In this case, we replace it by the result of initial string (and probably avoid string2bytes conversion)