### PR TITLE
Update package to scoped npm pkgname

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Install the library as a Node module.
 
 ```
-$ npm install --save x11-hash-js
+$ npm install --save @dashevo/x11-hash-js
 ```
 
 Reference the library within a Node module.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "x11-hash-js",
+  "name": "@dashevo/x11-hash-js",
   "version": "1.0.1",
   "description": "x11 javascript hashing algorithm in pure javascript",
   "main": "index.js",
@@ -33,7 +33,7 @@
   "author": "quantumexplorer",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/quantumexplorer/x11-hash-js/issues"
+    "url": "https://github.com/dashpay/x11-hash-js/issues"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",


### PR DESCRIPTION
With 1.0.1, we released under https://www.npmjs.com/package/x11-hash-js
But also under https://www.npmjs.com/package/@dashevo/x11-hash-js 

I would suggest that we keep 1.0.1 unchanged, but that we now released future version under this new package name. 

We will deprecate the old one at some point in the future (not needed now I guess).