### PR TITLE
Bump to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/x11-hash-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "x11 javascript hashing algorithm in pure javascript",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/quantumexplorer/x11-hash-js.git"
+    "url": "https://github.com/dashpay/x11-hash-js.git"
   },
   "keywords": [
     "x11",


### PR DESCRIPTION
When https://github.com/dashpay/x11-hash-js/pull/12 is merged. 
We should release publish as a new version.